### PR TITLE
NAS-109785 / . / Explain that what we see is not a crash but rather YAML parsing error

### DIFF
--- a/midcli/editor/edit_yaml.py
+++ b/midcli/editor/edit_yaml.py
@@ -24,7 +24,7 @@ def edit_yaml(schema, values, errors):
             doc = yaml.safe_load(text)
         except yaml.YAMLError as e:
             error_title = "YAML Syntax Error"
-            error_text = str(e)
+            error_text = f"The input you provided has invalid YAML syntax:\n\n{str(e)}"
         else:
             try:
                 args = yaml_to_args(schema, doc)


### PR DESCRIPTION
@Mrt134 I need your advice on choosing a correct term here. If we want to run a complicated action with CLI, instead of making user enter one long command, we open text editor and offer him to specify parameters in a visually formatted text file. This process can be seen on video here: https://jira.ixsystems.com/browse/NAS-109785

How should we call this file? I call it document now, but this is purely because our format (YAML) specification talks of "documents".