### PR TITLE
NAS-119674 / 23.10 / remove user.shell_choices override

### DIFF
--- a/midcli/context.py
+++ b/midcli/context.py
@@ -117,7 +117,6 @@ class Namespaces(object):
         'account.user.create': AccountCreateCommand,
         'account.user.update': AccountUpdateCommand,
         'account.user.delete': AccountItemMethodCommand,
-        'account.user.shell_choices': AccountItemMethodCommand,
         'account.user.set_attribute': AccountItemMethodCommand,
         'account.user.pop_attribute': AccountItemMethodCommand,
         'account.group.query': GroupQueryCommand,


### PR DESCRIPTION
A recent API backwards incompatible change was made which breaks CLI.