### PR TITLE
NAS-133699 / 25.04 / Add CLI menu item for generating a one-time password

### DIFF
--- a/midcli/menu/items.py
+++ b/midcli/menu/items.py
@@ -99,6 +99,13 @@ def shell(context):
     spawn_shell()
 
 
+def generate_onetime_password(context):
+    with context.get_client() as c:
+        username = c.call("auth.me")["pw_name"]
+        otp = c.call("auth.generate_onetime_password", {"username": username})
+        print(f'Onetime password for "{username}" is: {otp}')
+
+
 def reboot(context):
     if reason := input("Please enter the reason for the system reboot: ").strip():
         context.process_input(f"system reboot {json.dumps(reason)}")
@@ -118,6 +125,11 @@ def get_menu_items(context):
     with context.get_client() as c:
         if c.call("user.has_local_administrator_set_up"):
             menu_items.append(("Change local administrator password", manage_local_administrator_password))
+            try:
+               this_username = c.call("auth.me")["pw_name"]
+               menu_items.append((f'Create one-time password for "{this_username}"', generate_onetime_password))
+            except Exception as exc:
+               pass
         else:
             menu_items.append(("Set up local administrator", manage_local_administrator_password))
     menu_items += [

--- a/midcli/menu/items.py
+++ b/midcli/menu/items.py
@@ -125,11 +125,8 @@ def get_menu_items(context):
     with context.get_client() as c:
         if c.call("user.has_local_administrator_set_up"):
             menu_items.append(("Change local administrator password", manage_local_administrator_password))
-            try:
-               this_username = c.call("auth.me")["pw_name"]
-               menu_items.append((f'Create one-time password for "{this_username}"', generate_onetime_password))
-            except Exception as exc:
-               pass
+            this_username = c.call("auth.me")["pw_name"]
+            menu_items.append((f'Create one-time password for "{this_username}"', generate_onetime_password))
         else:
             menu_items.append(("Set up local administrator", manage_local_administrator_password))
     menu_items += [


### PR DESCRIPTION
This commit adds a menu item to generate a onetime password for the current user in a midcli session. This can be used for webui authentication when in STIG mode to comply with replay resistance requirements for authentication. The reason why someone may use this is to simplify recovery when a two-factor token is lost / configuration is broken.