### PR TITLE
Handle duplicate types in API schema

### DIFF
--- a/midcli/gui/base/steps/input.py
+++ b/midcli/gui/base/steps/input.py
@@ -1,8 +1,11 @@
 # -*- coding=utf-8 -*-
 from dataclasses import dataclass
 import logging
+from typing import TYPE_CHECKING, Callable
 
 from midcli.utils.lang import undefined
+if TYPE_CHECKING:
+    from midcli.gui.base.steps.input_delegate import InputDelegate
 
 logger = logging.getLogger(__name__)
 
@@ -16,4 +19,4 @@ class Input:
     empty: bool = undefined
     enum: list = undefined
     required: bool = undefined
-    delegate: object = None
+    delegate: Callable[[], "InputDelegate"] | None = None


### PR DESCRIPTION
## Problem
This schema is a result of changes made to the API:
```
{
  'anyOf': [
    {'const': '', 'enum': [''], 'type': 'string'},
    {'type': 'string'}
  ],
  'description': 'Used instead of the default gateway provided by DHCP.',
  'title': 'ipv4gateway',
  '_name_': 'ipv4gateway',
  '_required_': False
}
```
where both objects listed in `anyOf` have the same `type`.

## Solution
Handle duplicate types like this in `create_input_delegate`, and instead of returning `None`, raise an exception if the schema cannot be resolved to an `InputDelegate`.