### PR TITLE
NAS-135919 / 25.10 / fix overly alarming warning message

### DIFF
--- a/midcli/__main__.py
+++ b/midcli/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import errno
 import os
 import signal
 import sys
@@ -196,7 +197,8 @@ class CLI:
 
             history = FileHistory(history_file)
         except Exception as e:
-            print(f'WARNING: Unable to open history file: {e}')
+            if e.errno != errno.EPERM:
+                print(f'INFO: Unable to open history file: {e} (Using in memory history).')
             history = InMemoryHistory()
 
         self.loop = asyncio.get_event_loop()


### PR DESCRIPTION
This is causing too many tickets unnecessarily. It's virtually impossible to predict all the various combinations of user home directories/modifications etc etc that a user can perform. In this particular situation a user upgraded a CORE machine and truenas_admin has a home directory of /var/empty. But we disable the ability to modify it since it's a builtin account that we create.

Either way this does 2 things:
1. don't print any message if we get PermissionError
2. change the message to say "INFO" and let user know the history is being stored in memory.