### PR TITLE
NAS-141238 / 25.10.5 / Do not poll network interface status in CLI menu (by themylogin) (by bugclerk)

### DIFF
--- a/midcli/__main__.py
+++ b/midcli/__main__.py
@@ -233,7 +233,7 @@ class CLI:
         try:
             menu_items = get_menu_items(self.context)
             menu_app = self._build_menu(menu_items)
-            prompt_app = self._build_cli(history)
+            prompt_app = None
 
             while True:
                 if self.context.menu_item:
@@ -247,6 +247,9 @@ class CLI:
 
                     process_menu_item(self.context, menu_items, text)
                 else:
+                    if prompt_app is None:
+                        prompt_app = self._build_cli(history)
+
                     try:
                         text = prompt_app.prompt()
                     except KeyboardInterrupt:


### PR DESCRIPTION
Running `self._build_cli` starts a loop that polls network interface unapplied changes status from middleware. This (and polling the terminal width) are the only background activities on an idling CLI menu. Let's postpone starting the polling thread until the TrueNAS CLI is actually requested.

Original PR: https://github.com/truenas/midcli/pull/130


Original PR: https://github.com/truenas/midcli/pull/132
