### PR TITLE
NAS-141706 / 27.0.0-BETA.1 / Fix console menu failing to save HA interfaces with failover aliases (by creatorcary)

### DIFF
--- a/midcli/gui/network/interface/create_update.py
+++ b/midcli/gui/network/interface/create_update.py
@@ -1,4 +1,5 @@
 # -*- coding=utf-8 -*-
+import functools
 import logging
 
 from midcli.gui.base.steps.header import Header
@@ -19,10 +20,14 @@ class NetworkInterfaceCreate(Steps):
 
     method = StepsMethod.CREATE
 
-    def step1(self, data):
+    @functools.cached_property
+    def failover_licensed(self):
+        # A new `Steps` is built for every redraw, so this is re-fetched whenever the form
+        # is redrawn, and at most once per instance.
         with self.context.get_client() as c:
-            failover_licensed = c.call("failover.licensed")
+            return c.call("failover.licensed")
 
+    def step1(self, data):
         result = [Header("Interface Settings")]
 
         if self.method == StepsMethod.CREATE:
@@ -32,7 +37,7 @@ class NetworkInterfaceCreate(Steps):
             Input("name"),
             Input("description"),
         ])
-        if not failover_licensed:
+        if not self.failover_licensed:
             result.extend([
                 Input("ipv4_dhcp"),
                 Input("ipv6_auto"),
@@ -40,7 +45,7 @@ class NetworkInterfaceCreate(Steps):
         result.extend([
             Input("aliases", delegate=AliasesInputDelegate),
         ])
-        if failover_licensed:
+        if self.failover_licensed:
             result.extend([
                 Header("Failover Settings"),
                 Input("failover_critical"),
@@ -84,23 +89,20 @@ class NetworkInterfaceCreate(Steps):
             return result
 
     def process_data(self, data):
-        with self.context.get_client() as c:
-            failover_licensed = c.call("failover.licensed")
+        if self.failover_licensed:
+            data["ipv4_dhcp"] = False
+            data["ipv6_auto"] = False
 
-            if failover_licensed:
-                data["ipv4_dhcp"] = False
-                data["ipv6_auto"] = False
-
-                # `interface.query` reports failover aliases with a `netmask`, but
-                # `interface.create`/`interface.update` reject it. Values the user did not
-                # retype reach us verbatim from the query, so strip it before submitting.
-                # Rebuild rather than mutate: these dicts are shared with `self.data`.
-                for key in ("failover_aliases", "failover_virtual_aliases"):
-                    if aliases := data.get(key):
-                        data[key] = [
-                            {k: v for k, v in alias.items() if k != "netmask"}
-                            for alias in aliases
-                        ]
+            # `interface.query` reports failover aliases with a `netmask`, but
+            # `interface.create`/`interface.update` reject it. Values the user did not
+            # retype reach us verbatim from the query, so strip it before submitting.
+            # Rebuild rather than mutate: these dicts are shared with `self.data`.
+            for key in ("failover_aliases", "failover_virtual_aliases"):
+                if aliases := data.get(key):
+                    data[key] = [
+                        {k: v for k, v in alias.items() if k != "netmask"}
+                        for alias in aliases
+                    ]
 
 
 class NetworkInterfaceUpdate(NetworkInterfaceCreate):

--- a/midcli/gui/network/interface/create_update.py
+++ b/midcli/gui/network/interface/create_update.py
@@ -91,6 +91,17 @@ class NetworkInterfaceCreate(Steps):
                 data["ipv4_dhcp"] = False
                 data["ipv6_auto"] = False
 
+                # `interface.query` reports failover aliases with a `netmask`, but
+                # `interface.create`/`interface.update` reject it. Values the user did not
+                # retype reach us verbatim from the query, so strip it before submitting.
+                # Rebuild rather than mutate: these dicts are shared with `self.data`.
+                for key in ("failover_aliases", "failover_virtual_aliases"):
+                    if aliases := data.get(key):
+                        data[key] = [
+                            {k: v for k, v in alias.items() if k != "netmask"}
+                            for alias in aliases
+                        ]
+
 
 class NetworkInterfaceUpdate(NetworkInterfaceCreate):
     title = "Update Network Interface"

--- a/tests/gui/network/interface/test_process_data.py
+++ b/tests/gui/network/interface/test_process_data.py
@@ -8,9 +8,7 @@ from midcli.gui.network.interface.create_update import NetworkInterfaceCreate
 
 def steps(failover_licensed=True):
     steps = MagicMock()
-    client = MagicMock()
-    client.call.return_value = failover_licensed
-    steps.context.get_client.return_value.__enter__.return_value = client
+    steps.failover_licensed = failover_licensed
     return steps
 
 

--- a/tests/gui/network/interface/test_process_data.py
+++ b/tests/gui/network/interface/test_process_data.py
@@ -1,0 +1,65 @@
+# -*- coding=utf-8 -*-
+from unittest.mock import MagicMock
+
+import pytest
+
+from midcli.gui.network.interface.create_update import NetworkInterfaceCreate
+
+
+def steps(failover_licensed=True):
+    steps = MagicMock()
+    client = MagicMock()
+    client.call.return_value = failover_licensed
+    steps.context.get_client.return_value.__enter__.return_value = client
+    return steps
+
+
+def test_failover_alias_netmask_is_stripped():
+    # `interface.query` reports failover aliases with a `netmask` that `interface.update` rejects.
+    queried_failover = [{"type": "INET", "address": "10.217.120.8", "netmask": 25}]
+    queried_virtual = [{"type": "INET", "address": "10.217.120.9", "netmask": 32}]
+    data = {"failover_aliases": queried_failover, "failover_virtual_aliases": queried_virtual}
+
+    NetworkInterfaceCreate.process_data(steps(), data)
+
+    assert data["failover_aliases"] == [{"type": "INET", "address": "10.217.120.8"}]
+    assert data["failover_virtual_aliases"] == [{"type": "INET", "address": "10.217.120.9"}]
+
+
+def test_failover_aliases_from_query_are_not_mutated():
+    # `_save` copies these dicts by reference out of `self.data`, which is redrawn on error.
+    queried_failover = [{"type": "INET", "address": "10.217.120.8", "netmask": 25}]
+    queried_virtual = [{"type": "INET", "address": "10.217.120.9", "netmask": 32}]
+
+    NetworkInterfaceCreate.process_data(
+        steps(), {"failover_aliases": queried_failover, "failover_virtual_aliases": queried_virtual}
+    )
+
+    assert queried_failover == [{"type": "INET", "address": "10.217.120.8", "netmask": 25}]
+    assert queried_virtual == [{"type": "INET", "address": "10.217.120.9", "netmask": 32}]
+
+
+def test_aliases_keep_their_netmask():
+    data = {"aliases": [{"type": "INET", "address": "10.217.120.7", "netmask": 25}]}
+
+    NetworkInterfaceCreate.process_data(steps(), data)
+
+    assert data["aliases"] == [{"type": "INET", "address": "10.217.120.7", "netmask": 25}]
+
+
+@pytest.mark.parametrize("data", [{}, {"failover_aliases": [], "failover_virtual_aliases": []}])
+def test_absent_or_empty_failover_aliases(data):
+    expected = dict(data)
+
+    NetworkInterfaceCreate.process_data(steps(), data)
+
+    for key, value in expected.items():
+        assert data[key] == value
+
+
+def test_unlicensed_data_is_untouched():
+    data = {"failover_aliases": [{"type": "INET", "address": "10.217.120.8", "netmask": 25}]}
+
+    NetworkInterfaceCreate.process_data(steps(failover_licensed=False), data)
+
+    assert data == {"failover_aliases": [{"type": "INET", "address": "10.217.120.8", "netmask": 25}]}

--- a/tox.ini
+++ b/tox.ini
@@ -2,3 +2,8 @@
 exclude = integration_tests/*,tests/*
 ignore = F403,F405,W504
 max-line-length = 120
+
+[pytest]
+# Import midcli from this checkout rather than any copy already installed in the
+# CI container image (ghcr.io/truenas/middleware). Prepends the repo root to sys.path.
+pythonpath = .


### PR DESCRIPTION
## Root cause

`interface.query` and `interface.update` disagree about the shape of a failover alias. `iface_extend` returns `failover_aliases` and `failover_virtual_aliases` entries carrying a `netmask` key, but `InterfaceCreate`/`InterfaceUpdate` type both lists as `InterfaceCreateFailoverAlias`, which is `{type, address}` only, under `extra="forbid"`.

`Steps._save` builds its update payload by copying `self.data[input.name]` verbatim, and `self.data` is the entry returned by `interface.query`. So any failover alias the user did not retype is echoed straight back with its `netmask` attached, and the API rejects it:

```
[EINVAL] data.failover_aliases.0.netmask: Extra inputs are not permitted
[EINVAL] data.failover_virtual_aliases.0.netmask: Extra inputs are not permitted
```

The result is that on an HA-licensed system, any interface with failover aliases cannot be saved from the console menu at all. `AliasesInputDelegate(netmask=False)` already knew failover aliases take no netmask, but it only governs display and the parsing of newly typed text — never values left untouched. Despite the ticket title this is neither VLAN- nor MTU-specific; it reproduces on a physical interface with `mtu` unset.

## Fix

Strip `netmask` from both failover alias lists in `NetworkInterfaceCreate.process_data`, which `_save` already calls immediately before the API request. The dicts are rebuilt rather than mutated, because `_save` copies them out of `self.data` by reference and `self.data` is redrawn when validation fails.

`aliases` deliberately keeps its `netmask` — `InterfaceCreateAlias` accepts it; only the two failover lists don't.

## Testing

New unit tests cover the strip, the no-mutation guarantee, `aliases` retaining its netmask, and absent/empty/unlicensed cases. Verified end to end on an HA VM: unpatched, updating a physical interface and a VLAN both fail with the errors above; patched, both succeed and the parent-then-child jumbo MTU sequence completes.

Also includes two CI commits so `stable/26` PRs run unit tests at all — `unittests.yml` previously only triggered on `master`.

Original PR: https://github.com/truenas/midcli/pull/136
